### PR TITLE
Added a Typescript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+import { Component } from 'react';
+
+interface ConfirmInputProps {
+  value?: string
+  isChecked?: boolean
+  placeholder?: string
+  onChange?: (value:string) => void
+  onSubmit?: (checked:boolean) => void
+}
+
+declare class ConfirmInput extends Component<ConfirmInputProps> {}
+
+export = ConfirmInput;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
 		"test": "xo && ava"
 	},
 	"main": "dist.js",
+	"types": "index.d.ts",
 	"files": [
-		"dist.js"
+		"dist.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"boolean",
@@ -41,6 +43,7 @@
 		"@babel/cli": "^7.6.0",
 		"@babel/core": "^7.6.0",
 		"@babel/preset-react": "^7.0.0",
+		"@types/react": "^16.9.15",
 		"ava": "^2.3.0",
 		"chalk": "^2.4.2",
 		"eslint-config-xo-react": "^0.20.0",


### PR DESCRIPTION
The declaration file looks a lot like the existing `PropTypes` specification, and plays even better with VS Code!  I needed to add `@types/react` to get a proper definition of a Component, but other than that, very small changeset.

Please let me know if there are any style issues you'd like me to resolve!