### PR TITLE
Upgrade to ink v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"yes"
 	],
 	"dependencies": {
+		"delay": "^5.0.0",
 		"ink-text-input": "^4.0.1",
 		"prop-types": "^15.5.10",
 		"yn": "^3.1.1"
@@ -47,7 +48,7 @@
 		"eslint-plugin-react": "^7.1.0",
 		"eslint-plugin-react-hooks": "^2.0.1",
 		"ink": "^2.3.0",
-		"ink-testing-library": "^1.0.2",
+		"ink-testing-library": "^2.1.0",
 		"react": "^16.9.0",
 		"sinon": "^7.4.2",
 		"xo": "^0.24.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"yes"
 	],
 	"dependencies": {
-		"ink-text-input": "^3.2.1",
+		"ink-text-input": "^4.0.1",
 		"prop-types": "^15.5.10",
 		"yn": "^3.1.1"
 	},
@@ -53,7 +53,7 @@
 		"xo": "^0.24.0"
 	},
 	"peerDependencies": {
-		"ink": ">=2",
+		"ink": ">=3",
 		"react": ">=16"
 	},
 	"ava": {

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ import test from 'ava';
 import chalk from 'chalk';
 import {render} from 'ink-testing-library';
 import {spy} from 'sinon';
+import delay from 'delay';
 import ConfirmInput from '.';
 
 const CURSOR = chalk.inverse(' ');
@@ -21,13 +22,14 @@ test('render', t => {
 	t.is(lastFrame(), `Yes${CURSOR}`);
 });
 
-test('return boolean on submit', t => {
+test('return boolean on submit', async t => {
 	const onSubmit = spy();
 	const {lastFrame, stdin} = render(<StatefulConfirmInput onSubmit={onSubmit}/>);
 
 	t.is(lastFrame(), CURSOR);
 	stdin.write('Yes');
 	t.is(lastFrame(), `Yes${CURSOR}`);
+	await delay(100);
 
 	stdin.write(ENTER);
 	t.true(onSubmit.calledOnce);


### PR DESCRIPTION
This PR ugrades to ink v3 - The only change necessary was around testing. For some reason the `onSubmit` spy was failing and was fixed by adding a `delay` similar to what `ink-text-input` did for [upgrading to ink v3](https://github.com/vadimdemedes/ink-text-input/pull/58/commits/563fdb6f09c775770f1ab4b849c98df0239c8591).